### PR TITLE
Travis default scripts are pretty dumb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,17 @@
 language: java
+cache:
+  directories:
+    - $HOME/.m2
+#
+#  Travis default commands are pretty dumb
+#  - install is supposed to be the equivalent of "npm install", i.e download dependencies.
+#    However, their default command for this does an "mvn install", which as they say themselves in their doc, is much
+#    more than that.
+#    Was hoping to do a mvn dependency:resolve, but it fails on dependencies from the reactor.
+#    Skip it entirely, it's not like we changing dependencies every day.
+#
+#  - script is the thing that actually builds. Since we have caching, we don't actually want to install our built
+#    jars; we just do a 'verify'.
+#
+install: echo Skip me > /dev/null
+script: ./mvnw clean verify -B -V

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,11 @@
                         <release>11</release>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>3.1.1</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>


### PR DESCRIPTION
- adding cache, should speed builds
- install is supposed to be the equivalent of "npm install", i.e download dependencies. However, their default command for this does an "mvn install", which as they say themselves in their doc, is much more than that
- script is the thing that actually build. Since we're adding caching, we don't actually want to install our built jars; verify is where it's at