### PR TITLE
Fix Renovate config such that it distinguishes between minor and patch

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,7 @@
 {
   extends: ["config:base"],
   masterIssue: true,
+  separateMinorPatch: true,
   automerge: false,
   automergeType: "pr",
   // Wait 2 days after a release to create PR/branches


### PR DESCRIPTION

Automerge patch fixes otherwise doesn't work, since Renovate considers a patch to be a minor by default (https://docs.renovatebot.com/configuration-options/#separateminorpatch)