### PR TITLE
Fix maven and maven-wrapper grouping

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -33,7 +33,7 @@
     },
     // Group Maven and Maven-Wrapper upgrades
     {
-      matchManagers: ["maven", "maven-wrapper"],
+      matchManagers: ["maven-wrapper"],
       groupName: "Maven",
     },
     // Java packages rules:


### PR DESCRIPTION
* The maven-wrapper manager is used to upgrade both maven itself and the wrapper, but by default does so in separate PRs