### PR TITLE
Since Java23, annotation processors must be explicitely configured

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,9 @@
                         <release>21</release>
                         <source>21</source>
                         <target>21</target>
+                        <annotationProcessors>
+                            <processor>org.immutables.processor.ProxyProcessor</processor>
+                        </annotationProcessors>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/tichu-archunit/pom.xml
+++ b/tichu-archunit/pom.xml
@@ -72,6 +72,11 @@
             <artifactId>archunit-junit5</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- only because we've enabled the annotation processor for immutables in parent pom -->
+        <dependency>
+            <groupId>org.immutables</groupId>
+            <artifactId>value</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/tichu-embedded-tomcat/pom.xml
+++ b/tichu-embedded-tomcat/pom.xml
@@ -24,5 +24,10 @@
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
         </dependency>
+        <!-- only because we've enabled the annotation processor for immutables in parent pom -->
+        <dependency>
+            <groupId>org.immutables</groupId>
+            <artifactId>value</artifactId>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
- could also support previous behaviour with -proc:full but I'd rather be prudent too
- also likely to move to records and remove immutables altogether